### PR TITLE
feat: add options to format output

### DIFF
--- a/examples/concat.js
+++ b/examples/concat.js
@@ -24,4 +24,4 @@ bench.addFunction('plus', plus).addFunction('join', join).addFunction('concat', 
 bench.addResource('small array of strings', randomLetterArray({ length: 10 }));
 bench.addResource('large array of strings', randomLetterArray({ length: 100000 }));
 
-bench.run();
+bench.run({ format: 'classic' });

--- a/package.json
+++ b/package.json
@@ -39,5 +39,5 @@
 		"typescript": "^5.3.3",
 		"unbuild": "^2.0.0"
 	},
-	"packageManager": "pnpm@8.10.0"
+	"packageManager": "pnpm@8.13.1+sha256.9e5f62ce5f2b7d4ceb3c2848f41cf0b33032c24d683c7088b53f62b1885fb246"
 }

--- a/src/format.ts
+++ b/src/format.ts
@@ -1,0 +1,27 @@
+import type { BenchmarkResults, Options } from './types';
+
+export function format(format: Options['format'], results: BenchmarkResults): void {
+	console.log({ format, results });
+	switch (format) {
+		case 'classic': {
+			// [js-yaml] x 75.13 ops/sec ±4.82% (65 runs sampled)
+			// [yaml] x 5.97 ops/sec ±3.53% (20 runs sampled)
+			// The fastest was [js-yaml].
+			let result = '';
+			for (const { data, resource } of results) {
+				result += `\nResource: ${resource}`;
+				for (const bench of data) {
+					result += `${bench?.['Task Name']} x ${bench?.['ops/sec']} ops/sec ${bench?.Margin} (${bench?.Samples} runs sampled)`;
+				}
+			}
+			console.log(result);
+			break;
+		}
+		case 'modern': {
+			break;
+		}
+		case 'table': {
+			break;
+		}
+	}
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
+import type TinyBench from 'tinybench';
+
 export type BenchmarkFunction = {
 	name: string;
 	fn: (resource: BenchmarkResource['value']) => any;
@@ -9,3 +11,10 @@ export type BenchmarkResource = {
 	name: string;
 	value: any;
 };
+
+export type BenchmarkResults = {
+	data: ReturnType<TinyBench['table']>;
+	resource: string;
+}[];
+
+export type Options = { format: 'modern' | 'classic' | 'table' };


### PR DESCRIPTION
Currently not working since it tries to format before the event listeners fire. I guess I'll just have to output the results one at a time?